### PR TITLE
Redirect `installed` to `dependencies`

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -724,7 +724,7 @@ end
 ################
 
 function installed()
-    @warn "Pkg.installed() is deprecated"
+    @warn "Pkg.installed() is deprecated. Use Pkg.dependencies() instead."
     deps = dependencies()
     installs = Dict{String, VersionNumber}()
     for (uuid, dep) in deps

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -724,7 +724,10 @@ end
 ################
 
 function installed()
-    @warn "Pkg.installed() is deprecated. Use Pkg.dependencies() instead."
+    @warn "Pkg.installed() is deprecated. Use Pkg.dependencies() instead.
+    To get a list of package names that have been explicitly added to the 
+    current project (direct dependencies), you can do:
+    `[dep.second.name for dep in Pkg.dependencies() if dep.second.is_direct_dep]`."
     deps = dependencies()
     installs = Dict{String, VersionNumber}()
     for (uuid, dep) in deps


### PR DESCRIPTION
It is not clear from the current warning what should be used instead. This PR adds that information.

Some examples on how to use `dependencies` to get similar outputs as `installed` would also be nice, such as
```
julia> [dep.second.name for dep in Pkg.dependencies() if dep.second.is_direct_dep]
11-element Vector{String}:
 "CSV"
 "Accessors"
 "Unitful"
 "GLMakie"
 "DelimitedFiles"
 "DataFrames"
 "Tau"
 "OhMyREPL"
 "Revise"
 "BenchmarkTools"
 "XLSX"
```

(It is just a horribly clunky way to get a list of packages that have been `add`ed)